### PR TITLE
Fix github link in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add this to your application's `shard.yml`:
 ```yaml
 dependencies:
   ncurses:
-    github: jreinert/ncurses
+    github: jreinert/ncurses-crystal
 ```
 
 


### PR DESCRIPTION
Good day.

Wanted to use this library and noticed that `github` link in provided `shard.yml` example does not match the actual link.

KR, Oleksii.
