### PR TITLE
Window.initialize max height & width

### DIFF
--- a/src/ncurses/window.cr
+++ b/src/ncurses/window.cr
@@ -9,7 +9,7 @@ module NCurses
     ]
 
     def initialize(height = nil, width = nil, y = 0, x = 0)
-      max_height, max_width = NCurses.stdscr.max_dimensions
+      max_height, max_width = NCurses.stdscr.max_x, NCurses.stdscr.max_y
       initialize(LibNCurses.newwin(height || max_height, width || max_width, y, x))
     end
 


### PR DESCRIPTION
Changed from tuple due to error reported in Crystal 0.25.1